### PR TITLE
fix trt bug

### DIFF
--- a/torch2trt/trt_model.py
+++ b/torch2trt/trt_model.py
@@ -110,7 +110,7 @@ class TrtModel():
         cuda.memcpy_dtoh_async(host_outputs[0], cuda_outputs[0], stream)
         stream.synchronize()
         self.ctx.pop()
-        return host_outputs[0]
+        return host_outputs[0].copy()
 
 
     def destroy(self):


### PR DESCRIPTION

```python
pred_1=trt_model.infer(img_1)
pred_2=trt_model.infer(img_2)
```
Reason: pred2 will overwrite the contents of pred1 because they share memory.