### PR TITLE
Fix val2yolo.py and allow specify path to widerface from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Single Scale Inference on VGA resolution（max side is equal to 640 and scale).
 2. Download annotation files from [google drive](https://drive.google.com/file/d/1tU_IjyOwGQfGNUvZGwWWM4SwxKp2PUQ8/view?usp=sharing).
 
 ```shell
-python3 data/train2yolo.py /path/to/widerface/train
-python3 val2yolo.py
+cd data
+python3 train2yolo.py /path/to/original/widerface/train [/path/to/save/widerface/train]
+python3 val2yolo.py  /path/to/original/widerface [/path/to/save/widerface/val]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Single Scale Inference on VGA resolution（max side is equal to 640 and scale).
 2. Download annotation files from [google drive](https://drive.google.com/file/d/1tU_IjyOwGQfGNUvZGwWWM4SwxKp2PUQ8/view?usp=sharing).
 
 ```shell
-python3 train2yolo.py
+python3 data/train2yolo.py /path/to/widerface/train
 python3 val2yolo.py
 ```
 

--- a/data/train2yolo.py
+++ b/data/train2yolo.py
@@ -105,19 +105,29 @@ def detection_collate(batch):
 if __name__ == '__main__':
     if len(sys.argv) == 1:
         print('Missing path to WIDERFACE train folder.')
-        print('Run command: python3 train2yolo.py /path/to/widerface/train')
+        print('Run command: python3 train2yolo.py /path/to/original/widerface/train [/path/to/save/widerface/train]')
         exit(1)
-    elif len(sys.argv) > 2:
+    elif len(sys.argv) > 3:
         print('Too many arguments were provided.')
-        print('Run command: python3 train2yolo.py /path/to/widerface/train')
+        print('Run command: python3 train2yolo.py /path/to/original/widerface/train [/path/to/save/widerface/train]')
         exit(1)
+    original_path = sys.argv[1]
 
-    save_path = sys.argv[1]
-    if not os.path.isfile(os.path.join(save_path, 'label.txt')):
+    if len(sys.argv) == 2:
+        if not os.path.isdir('widerface'):
+            os.mkdir('widerface')
+        if not os.path.isdir('widerface/train'):
+            os.mkdir('widerface/train')
+
+        save_path = 'widerface/train'
+    else:
+        save_path = sys.argv[2]
+
+    if not os.path.isfile(os.path.join(original_path, 'label.txt')):
         print('Missing label.txt file.')
         exit(1)
 
-    aa = WiderFaceDetection(os.path.join(save_path, 'label.txt'))
+    aa = WiderFaceDetection(os.path.join(original_path, 'label.txt'))
 
     for i in range(len(aa.imgs_path)):
         print(i, aa.imgs_path[i])
@@ -159,7 +169,7 @@ if __name__ == '__main__':
                 annotation[0, 13] = label[17] / height  # l4_y
                 str_label = "0 "
                 for i in range(len(annotation[0])):
-                    str_label = str_label + " "+str(annotation[0][i])
+                    str_label = str_label + " " + str(annotation[0][i])
                 str_label = str_label.replace('[', '').replace(']', '')
                 str_label = str_label.replace(',', '') + '\n'
                 f.write(str_label)

--- a/data/val2yolo.py
+++ b/data/val2yolo.py
@@ -2,60 +2,87 @@ import os
 import cv2
 import numpy as np
 import shutil
+import sys
 from tqdm import tqdm
 
-root = '/ssd_1t/derron/WiderFace'
 
 def xywh2xxyy(box):
-	x1 = box[0]
-	y1 = box[1]
-	x2 = box[0] + box[2]
-	y2 = box[1] + box[3]
-	return (x1, x2, y1, y2)
+    x1 = box[0]
+    y1 = box[1]
+    x2 = box[0] + box[2]
+    y2 = box[1] + box[3]
+    return x1, x2, y1, y2
+
 
 def convert(size, box):
-	dw = 1. / (size[0])
-	dh = 1. / (size[1])
-	x = (box[0] + box[1]) / 2.0 - 1
-	y = (box[2] + box[3]) / 2.0 - 1
-	w = box[1] - box[0]
-	h = box[3] - box[2]
-	x = x * dw
-	w = w * dw
-	y = y * dh
-	h = h * dh
-	return (x, y, w, h)
+    dw = 1. / (size[0])
+    dh = 1. / (size[1])
+    x = (box[0] + box[1]) / 2.0 - 1
+    y = (box[2] + box[3]) / 2.0 - 1
+    w = box[1] - box[0]
+    h = box[3] - box[2]
+    x = x * dw
+    w = w * dw
+    y = y * dh
+    h = h * dh
+    return x, y, w, h
 
-def wider2face(phase='val', ignore_small=0):
-	data = {}
-	with open('{}/{}/label.txt'.format(root, phase), 'r') as f:
-		lines = f.readlines()
-		for line in tqdm(lines):
-			line = line.strip()
-			if '#' in line:
-				path = '{}/{}/images/{}'.format(root, phase, os.path.basename(line))
-				img = cv2.imread(path)
-				height, width, _ = img.shape
-				data[path] = list()
-			else:
-				box = np.array(line.split()[0:4], dtype=np.float32) # (x1,y1,w,h)
-				if box[2] < ignore_small or box[3] < ignore_small:
-					continue
-				box = convert((width, height), xywh2xxyy(box))
-				label = '0 {} {} {} {} -1 -1 -1 -1 -1 -1 -1 -1 -1 -1'.format(round(box[0],4), round(box[1],4), round(box[2],4), round(box[3],4))
-				data[path].append(label)
-	return data
+
+def wider2face(root, phase='val', ignore_small=0):
+    data = {}
+    with open('{}/{}/label.txt'.format(root, phase), 'r') as f:
+        lines = f.readlines()
+        for line in tqdm(lines):
+            line = line.strip()
+            if '#' in line:
+                path = '{}/{}/images/{}'.format(root, phase, line.split()[-1])
+                img = cv2.imread(path)
+                height, width, _ = img.shape
+                data[path] = list()
+            else:
+                box = np.array(line.split()[0:4], dtype=np.float32)  # (x1,y1,w,h)
+                if box[2] < ignore_small or box[3] < ignore_small:
+                    continue
+                box = convert((width, height), xywh2xxyy(box))
+                label = '0 {} {} {} {} -1 -1 -1 -1 -1 -1 -1 -1 -1 -1'.format(round(box[0], 4), round(box[1], 4),
+                                                                             round(box[2], 4), round(box[3], 4))
+                data[path].append(label)
+    return data
+
 
 if __name__ == '__main__':
-	datas = wider2face('val')
-	for idx, data in enumerate(datas.keys()):
-		pict_name = os.path.basename(data)
-		out_img = 'widerface/val/images/{}'.format(pict_name)
-		out_txt = 'widerface/val/labels/{}.txt'.format(os.path.splitext(pict_name)[0])
-		shutil.copyfile(data, out_img)
-		labels = datas[data]
-		f = open(out_txt, 'w')
-		for label in labels:
-			f.write(label + '\n')
-		f.close()
+    if len(sys.argv) == 1:
+        print('Missing path to WIDERFACE folder.')
+        print('Run command: python3 val2yolo.py /path/to/original/widerface [/path/to/save/widerface/val]')
+        exit(1)
+    elif len(sys.argv) > 3:
+        print('Too many arguments were provided.')
+        print('Run command: python3 val2yolo.py /path/to/original/widerface [/path/to/save/widerface/val]')
+        exit(1)
 
+    root_path = sys.argv[1]
+    if not os.path.isfile(os.path.join(root_path, 'val', 'label.txt')):
+        print('Missing label.txt file.')
+        exit(1)
+
+    if len(sys.argv) == 2:
+        if not os.path.isdir('widerface'):
+            os.mkdir('widerface')
+        if not os.path.isdir('widerface/val'):
+            os.mkdir('widerface/val')
+
+        save_path = 'widerface/val'
+    else:
+        save_path = sys.argv[2]
+
+    datas = wider2face(root_path, phase='val')
+    for idx, data in enumerate(datas.keys()):
+        pict_name = os.path.basename(data)
+        out_img = f'{save_path}/{idx}.jpg'
+        out_txt = f'{save_path}/{idx}.txt'
+        shutil.copyfile(data, out_img)
+        labels = datas[data]
+        f = open(out_txt, 'w')
+        for label in labels:
+            f.write(label + '\n')
+        f.close()

--- a/data/val2yolo_for_test.py
+++ b/data/val2yolo_for_test.py
@@ -1,0 +1,65 @@
+import os
+import cv2
+import numpy as np
+import shutil
+from tqdm import tqdm
+
+root = '/ssd_1t/derron/WiderFace'
+
+
+def xywh2xxyy(box):
+    x1 = box[0]
+    y1 = box[1]
+    x2 = box[0] + box[2]
+    y2 = box[1] + box[3]
+    return (x1, x2, y1, y2)
+
+
+def convert(size, box):
+    dw = 1. / (size[0])
+    dh = 1. / (size[1])
+    x = (box[0] + box[1]) / 2.0 - 1
+    y = (box[2] + box[3]) / 2.0 - 1
+    w = box[1] - box[0]
+    h = box[3] - box[2]
+    x = x * dw
+    w = w * dw
+    y = y * dh
+    h = h * dh
+    return (x, y, w, h)
+
+
+def wider2face(phase='val', ignore_small=0):
+    data = {}
+    with open('{}/{}/label.txt'.format(root, phase), 'r') as f:
+        lines = f.readlines()
+        for line in tqdm(lines):
+            line = line.strip()
+            if '#' in line:
+                path = '{}/{}/images/{}'.format(root, phase, os.path.basename(line))
+                img = cv2.imread(path)
+                height, width, _ = img.shape
+                data[path] = list()
+            else:
+                box = np.array(line.split()[0:4], dtype=np.float32)  # (x1,y1,w,h)
+                if box[2] < ignore_small or box[3] < ignore_small:
+                    continue
+                box = convert((width, height), xywh2xxyy(box))
+                label = '0 {} {} {} {} -1 -1 -1 -1 -1 -1 -1 -1 -1 -1'.format(round(box[0], 4), round(box[1], 4),
+                                                                             round(box[2], 4), round(box[3], 4))
+                data[path].append(label)
+    return data
+
+
+if __name__ == '__main__':
+    datas = wider2face('val')
+    for idx, data in enumerate(datas.keys()):
+        pict_name = os.path.basename(data)
+        out_img = 'widerface/val/images/{}'.format(pict_name)
+        out_txt = 'widerface/val/labels/{}.txt'.format(os.path.splitext(pict_name)[0])
+        shutil.copyfile(data, out_img)
+        labels = datas[data]
+        f = open(out_txt, 'w')
+        for label in labels:
+            f.write(label + '\n')
+        f.close()


### PR DESCRIPTION
Changes:

1. `train2yolo.py` now accepts path to dataset (and optional save path) as parameters instead of hard-coded path.
2. I tried using `val2yolo.py` with the dataset from [here](http://shuoyang1213.me/WIDERFACE/) to train from scratch but it always has FileNotFound issue so I reverted some of the code to the initial file before #46 (also accepts path from parameters now). Old code was moved to `val2yolo_for_test.py`.