### PR TITLE
torch 1.11.0 compatibility, Upsample

### DIFF
--- a/models/yolo.py
+++ b/models/yolo.py
@@ -228,6 +228,8 @@ class Model(nn.Module):
                 m.conv = fuse_conv_and_bn(m.conv, m.bn)  # update conv
                 delattr(m, 'bn')  # remove batchnorm
                 m.forward = m.fuseforward  # update forward
+            elif type(m) is nn.Upsample:
+                m.recompute_scale_factor = None  # torch 1.11.0 compatibility
         self.info()
         return self
 


### PR DESCRIPTION
fix Upsample object has no attribute recompute_scale_factor, torch 1.11.0 compatibility