### PR TITLE
Imported warnings in common.py

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -12,6 +12,8 @@ from utils.datasets import letterbox
 from utils.general import non_max_suppression, make_divisible, scale_coords, xyxy2xywh
 from utils.plots import color_list
 
+import warnings
+
 def autopad(k, p=None):  # kernel, padding
     # Pad to 'same'
     if p is None:


### PR DESCRIPTION
There was an error: "NameError: name 'warnings' is not defined". The solution was to simply import the module.

Reproduce steps:
1. python3 export.py --weights ./weights/yolov5s.pt --img 640 --batch 1
```
Namespace(batch_size=1, dynamic=False, fp16_trt=False, img_size=[640, 640], onnx2pb=False, onnx2trt=False, onnx_infer=True, weights='./weights/yolov5s.pt')
Fusing layers... 
Model Summary: 213 layers, 7225885 parameters, 0 gradients
Traceback (most recent call last):
  File "export.py", line 72, in <module>
    y = model(img)  # dry run
  File "/home/b4d/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/b4d/Documents/CMON/yolov5-face/models/yolo.py", line 180, in forward
    return self.forward_once(x, profile)  # single-scale inference, train
  File "/home/b4d/Documents/CMON/yolov5-face/models/yolo.py", line 196, in forward_once
    x = m(x)  # run
  File "/home/b4d/.local/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/b4d/Documents/CMON/yolov5-face/models/common.py", line 252, in forward
    with warnings.catch_warnings():
NameError: name 'warnings' is not defined
```