### PR TITLE
 fix clamp range

### DIFF
--- a/test_widerface.py
+++ b/test_widerface.py
@@ -36,16 +36,16 @@ def scale_coords_landmarks(img1_shape, coords, img0_shape, ratio_pad=None):
     coords[:, [1, 3, 5, 7, 9]] -= pad[1]  # y padding
     coords[:, :10] /= gain
     #clip_coords(coords, img0_shape)
-    coords[:, 0].clamp_(0, img0_shape[1])  # x1
-    coords[:, 1].clamp_(0, img0_shape[0])  # y1
-    coords[:, 2].clamp_(0, img0_shape[1])  # x2
-    coords[:, 3].clamp_(0, img0_shape[0])  # y2
-    coords[:, 4].clamp_(0, img0_shape[1])  # x3
-    coords[:, 5].clamp_(0, img0_shape[0])  # y3
-    coords[:, 6].clamp_(0, img0_shape[1])  # x4
-    coords[:, 7].clamp_(0, img0_shape[0])  # y4
-    coords[:, 8].clamp_(0, img0_shape[1])  # x5
-    coords[:, 9].clamp_(0, img0_shape[0])  # y5
+    coords[:, 0].clamp_(0, img0_shape[1] - 1)  # x1
+    coords[:, 1].clamp_(0, img0_shape[0] - 1)  # y1
+    coords[:, 2].clamp_(0, img0_shape[1] - 1)  # x2
+    coords[:, 3].clamp_(0, img0_shape[0] - 1)  # y2
+    coords[:, 4].clamp_(0, img0_shape[1] - 1)  # x3
+    coords[:, 5].clamp_(0, img0_shape[0] - 1)  # y3
+    coords[:, 6].clamp_(0, img0_shape[1] - 1)  # x4
+    coords[:, 7].clamp_(0, img0_shape[0] - 1)  # y4
+    coords[:, 8].clamp_(0, img0_shape[1] - 1)  # x5
+    coords[:, 9].clamp_(0, img0_shape[0] - 1)  # y5
     return coords
 
 def show_results(img, xywh, conf, landmarks, class_num):

--- a/utils/general.py
+++ b/utils/general.py
@@ -251,10 +251,10 @@ def scale_coords(img1_shape, coords, img0_shape, ratio_pad=None):
 
 def clip_coords(boxes, img_shape):
     # Clip bounding xyxy bounding boxes to image shape (height, width)
-    boxes[:, 0].clamp_(0, img_shape[1])  # x1
-    boxes[:, 1].clamp_(0, img_shape[0])  # y1
-    boxes[:, 2].clamp_(0, img_shape[1])  # x2
-    boxes[:, 3].clamp_(0, img_shape[0])  # y2
+    boxes[:, 0].clamp_(0, img_shape[1] - 1)  # x1
+    boxes[:, 1].clamp_(0, img_shape[0] - 1)  # y1
+    boxes[:, 2].clamp_(0, img_shape[1] - 1)  # x2
+    boxes[:, 3].clamp_(0, img_shape[0] - 1)  # y2
 
 
 def bbox_iou(box1, box2, x1y1x2y2=True, GIoU=False, DIoU=False, CIoU=False, eps=1e-9):


### PR DESCRIPTION
the expected range of the boxes and the landmarks should be between the range of [0, img_shape - 1] to avoid out of range exception when we try to access the landmarks later.

 Changes to be committed:
	modified:   test_widerface.py
	modified:   utils/general.py